### PR TITLE
Add Mapbox access token to the prod.Dockerfile

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,8 @@ services:
     build:
       context: .
       dockerfile: prod.Dockerfile
+      args:
+        - NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=${NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}
     env_file:
       - .env.db.local
       - .env.production.local

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -22,7 +22,8 @@ COPY tailwind.config.ts .
 
 # List any environment variables here
 ENV NODE_ENV=production
-
+ARG NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+ENV NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=${NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}
 ENV NEXT_TELEMETRY_DISABLED 1
 
 # Generate the Prisma client


### PR DESCRIPTION
This fixes issue #9.

The environment variable `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` was not being included during the build process. I had to create a .env file and add the token inside the file. Once added, I updated the YAML file and included the environment variable in the `args` instruction under `build`. Lastly, I updated the Dockerfile used in production to set the environment variable for `ARG` and `ENV`.