### PR TITLE
Bump node docker images from 20 to 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.16 AS base
+FROM node:22-alpine3.16 AS base
 
 # Step 1 - Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
This pull request bumps the Docker Node.js images used in the Dockerfiles from version 20 to version 22 (LTS) to address vulnerability issues.