### PR TITLE
Update env NEXT_TELEMETRY_DISABLED

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -20,7 +20,7 @@ COPY middleware.ts .
 COPY postcss.config.mjs .
 COPY tailwind.config.ts .
 
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 # Generate the Prisma client
 RUN npx prisma generate

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -57,6 +57,6 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 # List any environment variables here
 ENV NODE_ENV=production
 
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 CMD [ "npm", "run", "dockerfile-cmd:prod" ]


### PR DESCRIPTION
This pull request updates the `NEXT_TELEMETRY_DISABLED` environment variable to the new way of declaring environment variables in Dockerfiles.