### PR TITLE
Set base image from node 20 to node 22

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request sets the base image of the Dockerfile used for development from Node 20 to Node 22 (LTS).