### PR TITLE
Address alpine image that does not exist for node v22

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.16 AS base
+FROM node:22-alpine AS base
 
 # Step 1 - Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
This pull request addresses the issue where the alpine image 3.16 does not exist when using Node version 22.