### PR TITLE
Bugfix/prisma openssl issue

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22-alpine
 
+RUN apk add --no-cache openssl
 WORKDIR /app
 
 COPY package.json package-lock.json* ./

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
   ################################
   app.development:
     container_name: ncms_web_dev
-    image: ghcr.io/starlightroad/ncms-dev
     build:
       context: .
       dockerfile: dev.Dockerfile
@@ -15,7 +14,7 @@ services:
     ports:
       - 3000:3000
     expose:
-    - 3000
+      - 3000
     depends_on:
       - db.development
     volumes:
@@ -41,7 +40,6 @@ services:
   ################################
   app.production:
     container_name: ncms_web_prod
-    image: ghcr.io/starlightroad/ncms-prod
     build:
       context: .
       dockerfile: prod.Dockerfile
@@ -54,7 +52,7 @@ services:
     ports:
       - 3001:3001
     expose:
-    - 3001
+      - 3001
     depends_on:
       - db.production
     profiles:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native"]
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -46,6 +46,12 @@ RUN npm i dotenv-cli -g
 # Installs openssk, which is needed by Prisma
 RUN apk add --no-cache openssl
 
+# Install Prisma using the version listed in the package-lock.json file
+COPY package-lock.json ./
+RUN npm i "prisma@$(node -p "require('./package-lock.json').packages['node_modules/prisma'].version")"
+RUN npm cache clean --force
+RUN rm package-lock.json
+
 # Do not run production as root
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs


### PR DESCRIPTION
This PR includes changes that fixes issues with OpenSSL and Prisma.
- Added openssl to `prod.Dockerfile`.
- Removed the image keys from Compose.
- Added `linux-musl-openssl-3.0.x` to `binaryTargets` since Alpine Linux is the OS used.
- Added a `RUN` command via `prod.Dockerfile` that installs the Prisma version listed in `package-lock.json`.